### PR TITLE
Fix mocha for newer versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,12 +12,15 @@
   },
   "scripts": {
     "watch": "coffee -wclo lib source",
-    "test": "NODE_ENV=test mocha --compilers coffee:coffee-script --require coffee-script --colors"
+    "test": "NODE_ENV=test mocha --compilers coffee:coffee-script/register --colors"
   },
   "dependencies": {
     "coffee-script": "~1.7.1",
     "exec-sync": "~0.1.6",
     "minimist": "~0.0.7",
     "glob": "~3.2.8"
+  },
+  "devDependencies": {
+    "mocha": "^2.3.3"
   }
 }


### PR DESCRIPTION
I was not able to run the tests.

```
/usr/local/lib/node_modules/coffee-script/lib/coffee-script/coffee-script.js:195
          throw new Error("Use CoffeeScript.register() or require the coffee-s
                ^
Error: Use CoffeeScript.register() or require the coffee-script/register module to require .coffee.md files.
```

Add mocha as dev dependency and use register syntax.