### PR TITLE
Remove exec-sync dependency

### DIFF
--- a/lib/clog.js
+++ b/lib/clog.js
@@ -2,7 +2,7 @@
 (function() {
   var churn, complexity, count, execSync, files, fs, glob, gpa, isLiterate, report, rules, tokens, tokensForFile;
 
-  execSync = require("exec-sync");
+  execSync = require("child_process").execSync;
 
   tokens = require("coffee-script").tokens;
 

--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
   },
   "dependencies": {
     "coffee-script": "~1.7.1",
-    "exec-sync": "~0.1.6",
     "minimist": "~0.0.7",
     "glob": "~3.2.8"
   }

--- a/source/clog.coffee.md
+++ b/source/clog.coffee.md
@@ -5,7 +5,7 @@ Leverages CoffeeScript compiler, walking over all tokens
 in a file and weighing the code based on a number of heuristics
 corresponding to the token type.
 
-    execSync = require "exec-sync"
+    execSync = require("child_process").execSync
     {tokens} = require "coffee-script"
     rules = require "../lib/rules"
 

--- a/test/cli.coffee
+++ b/test/cli.coffee
@@ -1,5 +1,5 @@
 assert = require "assert"
-execSync = require "exec-sync"
+execSync = require("child_process").execSync
 
 describe "cli", ->
   it "prints out usage instructions", ->


### PR DESCRIPTION
[exec-sync](https://www.npmjs.com/package/exec-sync) is unmaintained and references an ancient and fixed version of ffi. Node 0.12 introduced [the same functionality](https://nodejs.org/api/child_process.html#child_process_child_process_execsync_command_options).